### PR TITLE
Support vertical pan and swipe gestures

### DIFF
--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -36,6 +36,12 @@ var HammerComponent = React.createClass({
 	
 	componentDidMount: function() {
 		this.hammer = new Hammer(this.getDOMNode());
+
+		if (this.props.vertical) {
+			this.hammer.get('pan').set({ direction: Hammer.DIRECTION_ALL });
+			this.hammer.get('swipe').set({ direction: Hammer.DIRECTION_ALL });
+		}
+
 		if (this.props.action)          this.hammer.on('tap press', this.props.action);
 		if (this.props.onTap)           this.hammer.on('tap', this.props.onTap);
 		if (this.props.onDoubleTap)     this.hammer.on('doubletap', this.props.onDoubleTap);
@@ -44,11 +50,6 @@ var HammerComponent = React.createClass({
 		if (this.props.onPress)         this.hammer.on('press', this.props.onPress);
 		if (this.props.onPinch)         this.hammer.on('pinch', this.props.onPinch);
 		if (this.props.onRotate)        this.hammer.on('rotate', this.props.onRotate);
-
-		if (this.props.vertical) {
-			this.hammer.get('pan').set({ direction: Hammer.DIRECTION_ALL });
-			this.hammer.get('swipe').set({ direction: Hammer.DIRECTION_ALL });
-		}
 	},
 	
 	componentWillUnmount: function() {

--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -8,9 +8,7 @@ var privateProps = {
 	onTap: true,
 	onDoubleTap: true,
 	onPan: true,
-	onVerticalPan: true,
 	onSwipe: true,
-	onVerticalSwipe: true,
 	onPress: true,
 	onPinch: true,
 	onRotate: true
@@ -42,15 +40,15 @@ var HammerComponent = React.createClass({
 		if (this.props.onTap)           this.hammer.on('tap', this.props.onTap);
 		if (this.props.onDoubleTap)     this.hammer.on('doubletap', this.props.onDoubleTap);
 		if (this.props.onPan)           this.hammer.on('pan', this.props.onPan);
-		if (this.props.onVerticalPan)   this.hammer.on('pan panup pandown panstart ' +
-																									 'panmove panend pancancel',
-																										this.props.onVerticalPan);
 		if (this.props.onSwipe)         this.hammer.on('swipe', this.props.onSwipe);
-		if (this.props.onVerticalSwipe) this.hammer.on('swipe swipeup swipedown',
-																									 this.props.onVerticalSwipe);
 		if (this.props.onPress)         this.hammer.on('press', this.props.onPress);
 		if (this.props.onPinch)         this.hammer.on('pinch', this.props.onPinch);
 		if (this.props.onRotate)        this.hammer.on('rotate', this.props.onRotate);
+
+		if (this.props.vertical) {
+			debugger;
+			this.hammer.set({ direction: Hammer.DIRECTION_ALL });
+		}
 	},
 	
 	componentWillUnmount: function() {

--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -8,7 +8,9 @@ var privateProps = {
 	onTap: true,
 	onDoubleTap: true,
 	onPan: true,
+	onVerticalPan: true,
 	onSwipe: true,
+	onVerticalSwipe: true,
 	onPress: true,
 	onPinch: true,
 	onRotate: true
@@ -39,8 +41,13 @@ var HammerComponent = React.createClass({
 		if (this.props.action)          this.hammer.on('tap press', this.props.action);
 		if (this.props.onTap)           this.hammer.on('tap', this.props.onTap);
 		if (this.props.onDoubleTap)     this.hammer.on('doubletap', this.props.onDoubleTap);
-		if (this.props.onPan)           this.hammer.on('pan panmove panend pancancel panleft panright panup pandow', this.props.onPan);
+		if (this.props.onPan)           this.hammer.on('pan', this.props.onPan);
+		if (this.props.onVerticalPan)   this.hammer.on('pan panup pandown panstart ' +
+																									 'panmove panend pancancel',
+																										this.props.onVerticalPan);
 		if (this.props.onSwipe)         this.hammer.on('swipe', this.props.onSwipe);
+		if (this.props.onVerticalSwipe) this.hammer.on('swipe swipeup swipedown',
+																									 this.props.onVerticalSwipe);
 		if (this.props.onPress)         this.hammer.on('press', this.props.onPress);
 		if (this.props.onPinch)         this.hammer.on('pinch', this.props.onPinch);
 		if (this.props.onRotate)        this.hammer.on('rotate', this.props.onRotate);

--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -46,8 +46,8 @@ var HammerComponent = React.createClass({
 		if (this.props.onRotate)        this.hammer.on('rotate', this.props.onRotate);
 
 		if (this.props.vertical) {
-			debugger;
-			this.hammer.set({ direction: Hammer.DIRECTION_ALL });
+			this.hammer.get('pan').set({ direction: Hammer.DIRECTION_ALL });
+			this.hammer.get('swipe').set({ direction: Hammer.DIRECTION_ALL });
 		}
 	},
 	


### PR DESCRIPTION
By default, Hammer only enables horizontal gestures on Pan and Swipe. I added an additional parameter to enable vertical gestures. I also removed the explicit `panstart`, `panmove`, et al event listeners, the main `pan` event encompasses them by default.

http://hammerjs.github.io/recognizer-pan/
http://hammerjs.github.io/recognizer-swipe/