### PR TITLE
error-friendly componentWillUnmount

### DIFF
--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -53,8 +53,10 @@ var HammerComponent = React.createClass({
 	},
 	
 	componentWillUnmount: function() {
-		this.hammer.stop();
-		this.hammer.destroy();
+		if (this.hammer) {
+		    this.hammer.stop();
+		    this.hammer.destroy();
+		}
 		this.hammer = null;
 	},
 	


### PR DESCRIPTION
in some rare (unexplained yet) cases the componentWillUnmount can be called without `this.hammer` initialiased and it breaks in theses cases.