### PR TITLE
Adding support for recognizeWith and more pan and pinch events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hammerjs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "ReactJS / HammerJS integration. Support touch events in your React app.",
   "main": "src/Hammer.js",
   "author": "Jed Watson",
@@ -10,7 +10,7 @@
     "url": "https://github.com/JedWatson/react-hammerjs.git"
   },
   "dependencies": {
-    "hammerjs": "^2.0.4"
+    "hammerjs": "https://github.com/hammerjs/hammer.js.git#189098ff7736f6ed2fce9a3d3e1f5a3afee085ba"
   },
   "devDependencies": {
     "browserify": "^11.2.0",

--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -13,12 +13,16 @@ var privateProps = {
 	onPan: true,
 	onPanStart: true,
 	onPanEnd: true,
+	onPanCancel: true,
 	onSwipe: true,
 	onPress: true,
 	onPressUp: true,
 	onPinch: true,
 	onPinchIn: true,
 	onPinchOut: true,
+	onPinchStart: true,
+	onPinchEnd: true,
+	onPinchCancel: true,
 	onRotate: true
 };
 
@@ -34,12 +38,15 @@ var handlerToEvent = {
 	onPanStart: 'panstart',
 	onPan: 'pan',
 	onPanEnd: 'panend',
+	onPanCancel: 'pancancel',
 	onSwipe: 'swipe',
 	onPress: 'press',
 	onPressUp: 'pressup',
 	onPinch: 'pinch',
 	onPinchIn: 'pinchin',
 	onPinchOut: 'pinchout',
+	onPinchStart: 'pinchstart',
+	onPinchEnd: 'pinchend',
 	onRotate: 'rotate'
 };
 function updateHammer(hammer, props) {

--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -75,10 +75,10 @@ function updateHammer(hammer, props) {
 	}
 	
 	if (props.recognizeWith) {
-		Object.keys(props.recognizeWith).forEach(function (gesture)) {
-			var recognizer = hammer.get(gesture)
-			recognizer.recognizeWith(props.recognizeWith[gesture])
-		}
+		Object.keys(props.recognizeWith).forEach(function (gesture) {
+			var recognizer = hammer.get(gesture);
+			recognizer.recognizeWith(props.recognizeWith[gesture]);
+		}, this);
 	}
 
 	Object.keys(props).forEach(function (p) {

--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -73,6 +73,13 @@ function updateHammer(hammer, props) {
 			}
 		}, this);
 	}
+	
+	if (props.recognizeWith) {
+		Object.keys(props.recognizeWith).forEach(function (gesture)) {
+			var recognizer = hammer.get(gesture)
+			recognizer.recognizeWith(props.recognizeWith[gesture])
+		}
+	}
 
 	Object.keys(props).forEach(function (p) {
 		var e = handlerToEvent[p];


### PR DESCRIPTION
Added onPanCancel, onPinchStart, onPinchEnd, and onPinchCancel.
Added support for using recognizeWith.

Usage for recognizeWith looks like:
```jsx
<Hammer
  recognizeWith={{ pinch: 'rotate', pan: 'press', tap: ['doubleTap', 'swipe'] }} >
    ...
</Hammer>
```

The bump of the hammer version to a more recent commit is actually irrelevant to these changes.