### PR TITLE
fix react warning

### DIFF
--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -6,6 +6,9 @@ var ReactDOM = require('react-dom');
 var Hammer = (typeof window !== 'undefined') ? require('hammerjs') : undefined;
 
 var privateProps = {
+	options: true,
+	recognizeWith: true,
+	vertical: true,
 	children: true,
 	action: true,
 	onTap: true,


### PR DESCRIPTION
react 15.2.0 will warn if non-dom attributes passed to dom elements.

@JedWatson 