### PR TITLE
Use ref instead of ReactDOM.findDOMNode()

### DIFF
--- a/src/Hammer.js
+++ b/src/Hammer.js
@@ -99,7 +99,7 @@ var HammerComponent = React.createClass({
 	},
 
 	componentDidMount: function () {
-		this.hammer = new Hammer(ReactDOM.findDOMNode(this));
+		this.hammer = new Hammer(this.domElement);
 		updateHammer(this.hammer, this.props);
 	},
 
@@ -125,6 +125,14 @@ var HammerComponent = React.createClass({
 				props[i] = this.props[i];
 			}
 		}, this);
+
+		var self = this;
+		props.ref = function(domElement) {
+			if (self.props.ref) {
+				self.props.ref(domElement);
+			}
+			self.domElement = domElement;
+		};
 
 		// Reuse the child provided
 		// This makes it flexible to use whatever element is wanted (div, ul, etc)


### PR DESCRIPTION
ReactDOM.findDOMNode() is discouraged, so we use refs instead (https://facebook.github.io/react/docs/react-dom.html#finddomnode).
This allows us to use this in our server-side render correctly.